### PR TITLE
Fixes mismatched printf format specifiers + support compiling on MacOS

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,9 @@
 
 set -x
 aclocal-1.9 || aclocal 
-libtoolize --force --copy
+# Darwin bizarrely uses glibtoolize
+libtoolize --force --copy ||
+	glibtoolize --force --copy
 autoheader
 automake-1.9 --add-missing --copy --foreign ||
         automake --add-missing --copy --foreign

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -321,7 +321,7 @@ static int decode(wandder_decoder_t *dec, uint8_t *ptr, wandder_item_t *parent) 
             //definite long form
             if (lenoctets > sizeof(item->length)) {
                 fprintf(stderr, "libwandder does not support length fields longer than %zd bytes right now\n", sizeof(item->length));
-                fprintf(stderr, "Tried to decode an item with a length field of %u bytes.\n", lenoctets);
+                fprintf(stderr, "Tried to decode an item with a length field of %" PRIu8 " bytes.\n", lenoctets);
                 if (item != dec->current) {
                     free_item(item);
                 }
@@ -615,10 +615,10 @@ const char *wandder_get_tag_string(wandder_decoder_t *dec) {
                 return "Set";
         }
     } else if (class == WANDDER_CLASS_CONTEXT_PRIMITIVE) {
-        snprintf(tmp, 2048, "[%u] (primitive)", ident);
+        snprintf(tmp, 2048, "[%" PRIu32 "] (primitive)", ident);
         return (const char *)tmp;
     } else if (class == WANDDER_CLASS_CONTEXT_CONSTRUCT) {
-        snprintf(tmp, 2048, "[%u] (construct)", ident);
+        snprintf(tmp, 2048, "[%" PRIu32 "] (construct)", ident);
         return (const char *)tmp;
     }
 
@@ -763,7 +763,7 @@ static uint32_t stringify_integer(uint8_t *start, uint32_t length, char *space,
         uint16_t spacerem) {
 
     int64_t intval = decode_integer(start, &length);
-    snprintf(space, spacerem - 1, "%ld", intval);
+    snprintf(space, spacerem - 1, "%" PRId64, intval);
     return length;
 }
 
@@ -806,7 +806,7 @@ static inline uint16_t oid_to_string(uint8_t *start, uint32_t length,
             return 0;
         }
 
-        snprintf(tmp, 1024, ".%u", nextval);
+        snprintf(tmp, 1024, ".%" PRIu32, nextval);
         strncat(space, tmp, spacerem - used);
 
         used += strlen(tmp);
@@ -971,12 +971,12 @@ char * wandder_get_valuestr(wandder_item_t *c, char *space, uint16_t len,
         if (c->identifier <= 31) {
             datatype = c->identifier;
         } else {
-            fprintf(stderr, "Unexpected identifier for supposedly universal tag: %u\n", c->identifier);
+            fprintf(stderr, "Unexpected identifier for supposedly universal tag: %" PRIu32 "\n", c->identifier);
             return NULL;
         }
     } else {
         if (interpretas > 31) {
-            fprintf(stderr, "'Interpret as' tags must be between 0-31 inclusive (not %u)\n", interpretas);
+            fprintf(stderr, "'Interpret as' tags must be between 0-31 inclusive (not %" PRIu8 ")\n", interpretas);
             return NULL;
         }
 
@@ -1033,7 +1033,7 @@ char * wandder_get_valuestr(wandder_item_t *c, char *space, uint16_t len,
         case WANDDER_TAG_REAL:
         case WANDDER_TAG_NUMERIC:
         default:
-            fprintf(stderr, "No stringify support for type %u just yet...\n",
+            fprintf(stderr, "No stringify support for type %" PRIu8 " just yet...\n",
                     datatype);
             return NULL;
     }
@@ -1301,11 +1301,11 @@ int wandder_decode_dump(wandder_decoder_t *dec, uint16_t level,
                 return -1;
             }
 
-            printf("[%u] %u %s %s\n", ident, level, act->name, space);
+            printf("[%" PRIu32 "] %" PRIu16 " %s %s\n", ident, level, act->name, space);
         }
 
         if (wandder_get_class(dec) == WANDDER_CLASS_CONTEXT_CONSTRUCT) {
-            printf("[%u] %u %s --\n", ident, level, act->name);
+            printf("[%" PRIu32 "] %" PRIu16 " %s --\n", ident, level, act->name);
 
             assert(act->descend != NULL);
             ret = wandder_decode_dump(dec, level + 1, act->descend, act->name);
@@ -1320,11 +1320,11 @@ int wandder_decode_dump(wandder_decoder_t *dec, uint16_t level,
                 return -1;
             }
 
-            printf("[%u] %u %s %s\n", ident, level, act->name, space);
+            printf("[%" PRIu32 "] %" PRIu16 " %s %s\n", ident, level, act->name, space);
         }
 
         if (wandder_get_class(dec) == WANDDER_CLASS_UNIVERSAL_CONSTRUCT) {
-            printf("%u %s --\n", level, actions->sequence.name);
+            printf("%" PRIu16 " %s --\n", level, actions->sequence.name);
             ret = wandder_decode_dump(dec, level + 1,
                     actions->sequence.descend, actions->sequence.name);
 

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -416,7 +416,7 @@ static inline int encode_time_inline(
             strftime(timebuf, 768, "%y%m%d%H%M%S", &tm);
             break;
     }
-    snprintf(returnbuf, 1024, "%s.%03ldZ", timebuf,
+    snprintf(returnbuf, 1024, "%s.%03" PRId64 "Z", timebuf,
             (int64_t)(tv->tv_usec / 1000));
 
     return strlen(returnbuf);
@@ -1164,7 +1164,7 @@ wandder_buf_t * wandder_encode_new_ber(
     itembuf->len = ret;
 
     if(ret != totallen){
-        printf("calc length:%4lu, real length:%4lu\n", totallen, ret);
+        printf("calc length:%4lu, real length:%4zu\n", totallen, ret);
         assert(0);
     }
 
@@ -1194,7 +1194,7 @@ size_t ber_rebuild_integer(
     } else if (vallen == 1) {
         val = *((int8_t *)valptr);
     } else {
-        fprintf(stderr, "Encode error: unexpected length for integer type: %lu\n",
+        fprintf(stderr, "Encode error: unexpected length for integer type: %zu\n",
             vallen);
         return 0;
     }

--- a/src/libwandder_etsili.c
+++ b/src/libwandder_etsili.c
@@ -285,7 +285,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
             {
                 if (stringify_ipaddress(etsidec, etsidec->dec->current, curr,
                         valstr, 2048) == NULL) {
-                    fprintf(stderr, "Failed to interpret IP field %d:%d\n",
+                    fprintf(stderr, "Failed to interpret IP field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -294,7 +294,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
             else if (curr->members[ident].interpretas == WANDDER_TAG_ENUM) {
                 if (interpret_enum(etsidec, etsidec->dec->current, curr,
                             valstr, 2048) == NULL) {
-                    fprintf(stderr, "Failed to interpret enum field %d:%d\n",
+                    fprintf(stderr, "Failed to interpret enum field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -303,7 +303,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
                 if (stringify_3gimei(etsidec, etsidec->dec->current, curr,
                             valstr, 2048) == NULL) {
                     fprintf(stderr,
-                            "Failed to interpret 3G IMEI-style field %d:%d\n",
+                            "Failed to interpret 3G IMEI-style field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -313,7 +313,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
                 if (stringify_3gcause(etsidec, etsidec->dec->current, curr,
                             valstr, 2048) == NULL) {
                     fprintf(stderr,
-                            "Failed to interpret 3G SM-Cause field %d:%d\n",
+                            "Failed to interpret 3G SM-Cause field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -322,7 +322,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
                 if (stringify_domain_name(etsidec, etsidec->dec->current, curr,
                             valstr, 2048) == NULL) {
                     fprintf(stderr,
-                            "Failed to interpret domain name field %d:%d\n",
+                            "Failed to interpret domain name field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -331,7 +331,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
                 if (stringify_bytes_as_hex(etsidec, etsidec->dec->current, curr,
                             valstr, 2048) == NULL) {
                     fprintf(stderr,
-                            "Failed to interpret hex bytes field %d:%d\n",
+                            "Failed to interpret hex bytes field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -340,7 +340,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
                 if (stringify_tai(etsidec, etsidec->dec->current, curr,
                             valstr, 2048) == NULL) {
                     fprintf(stderr,
-                            "Failed to interpret TAI field %d:%d\n",
+                            "Failed to interpret TAI field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -349,7 +349,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
                 if (stringify_ecgi(etsidec, etsidec->dec->current, curr,
                             valstr, 2048) == NULL) {
                     fprintf(stderr,
-                            "Failed to interpret ECGI field %d:%d\n",
+                            "Failed to interpret ECGI field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -358,7 +358,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
                 if (stringify_cgi(etsidec, etsidec->dec->current, curr,
                             valstr, 2048) == NULL) {
                     fprintf(stderr,
-                            "Failed to interpret CGI field %d:%d\n",
+                            "Failed to interpret CGI field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -367,7 +367,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
                 if (stringify_sai(etsidec, etsidec->dec->current, curr,
                             valstr, 2048) == NULL) {
                     fprintf(stderr,
-                            "Failed to interpret SAI field %d:%d\n",
+                            "Failed to interpret SAI field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -375,7 +375,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
             else {
                 if (!wandder_get_valuestr(etsidec->dec->current, valstr, 2048,
                         curr->members[ident].interpretas)) {
-                    fprintf(stderr, "Failed to interpret field %d:%d\n",
+                    fprintf(stderr, "Failed to interpret field %d:%" PRIu32 "\n",
                             etsidec->stack->current, ident);
                     return NULL;
                 }
@@ -390,7 +390,7 @@ char *wandder_etsili_get_next_fieldstr(wandder_etsispec_t *etsidec, char *space,
             (etsidec->stack->atthislevel[etsidec->stack->current])++;
             if (!wandder_get_valuestr(etsidec->dec->current, valstr, 2048,
                     wandder_get_identifier(etsidec->dec))) {
-                fprintf(stderr, "Failed to interpret standard field %d:%d\n",
+                fprintf(stderr, "Failed to interpret standard field %d:%" PRIu32 "\n",
                         etsidec->stack->current, ident);
                 return NULL;
             }
@@ -1020,7 +1020,7 @@ static const char *stringify_ipaddress(wandder_etsispec_t *etsidec,
         family = AF_INET6;
         addr = &in6;
     } else {
-        fprintf(stderr, "Unexpected IP address length: %lu\n", item->length);
+        fprintf(stderr, "Unexpected IP address length: %" PRIu64 "\n", item->length);
         return NULL;
     }
 
@@ -4174,7 +4174,7 @@ static void update_etsili_umtsiri(
         fprintf(stderr, "wandder: UMTS IRI record may be invalid...\n");
     } else {
         char space[24];
-        snprintf(space, 24, "%lu", *((uint64_t *)(p->itemptr)));
+        snprintf(space, 24, "%" PRIu64, *((uint64_t *)(p->itemptr)));
 
         encode_here_ber_update(
                 18, WANDDER_CLASS_CONTEXT_PRIMITIVE, WANDDER_TAG_OCTETSTRING,


### PR DESCRIPTION
Fixes a few printf format specifier mismatches.
The most important of which, are the corrections to printing `[u]int64_t` types.

Additionally, updates bootstrap to fallback to glibtoolize.

With these changes, the code now compiles on MacOS.